### PR TITLE
Adds argument check and valid node into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ git clone https://github.com/damons/amon
 ## Usage
 
 ```
-$ ./amon.sh 10.0.1.13 3030 15
+$ ./amon.sh 50.18.246.201 3030 15
 ```
 
 Where the first argument (`10.0.1.13`) is the IP of the node and second argument, `3030` is the port of the Aleo RPC server, and the third argument,  `15` , is the number of seconds between refresh.
@@ -43,7 +43,7 @@ Where the first argument (`10.0.1.13`) is the IP of the node and second argument
 Sample output:
 
 ```
-AMON - Monitoring snarkOS node: 10.0.1.89
+AMON - Monitoring snarkOS node: 50.18.246.201
 -----------------------------------------------
 PEERS:
 [

--- a/amon.sh
+++ b/amon.sh
@@ -3,19 +3,25 @@
 #
 while true 
 	do
+    # check that args were passed
+    if [ -z "$1" ]; then
+        echo "Please, specify IP and (optionally) port of RPC server";
+        echo "Example: $ ./amon.sh 10.0.1.13 3030";
+        exit 1;
+    fi;
 	clear; 
         printf "AMON - Monitoring snarkOS node: $1\n"
 	echo "-----------------------------------------------"
 	echo "PEERS:";
-	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getpeerinfo", "params": [] }' -H 'content-type: application/json' http://$1:$2/   | jq '.[].peers?';
+	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getpeerinfo", "params": [] }' -H 'content-type: application/json' http://$1:${2:-3030}/   | jq '.[].peers?';
 
 	echo "NODE INFO:";
-	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getnodeinfo", "params": [] }' -H 'content-type: application/json' http://$1:$2/ | jq '.result?';
+	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getnodeinfo", "params": [] }' -H 'content-type: application/json' http://$1:${2:-3030}/ | jq '.result?';
 
 	printf "CONNECTION COUNT:\t";
-	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getconnectioncount", "params": [] }' -H 'content-type: application/json' http://$1:$2/ | jq '.result?';
+	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getconnectioncount", "params": [] }' -H 'content-type: application/json' http://$1:${2:-3030}/ | jq '.result?';
 
 	printf "BLOCK COUNT:\t\t";
-	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getblockcount", "params": [] }' -H 'content-type: application/json' http://$1:$2/ | jq '.result?';
-	sleep $3; 
+	curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getblockcount", "params": [] }' -H 'content-type: application/json' http://$1:${2:-3030}/ | jq '.result?';
+	sleep ${3:-1}; 
 done


### PR DESCRIPTION
Now when called without arguments, it suggests to add one:

```bash
$ ./amon.sh                                                     
Please, specify IP and (optionally) port of RPC server
Example: $ ./amon.sh 10.0.1.13 3030
```

Also changes IP in README to a working server - may help for quick setup.

